### PR TITLE
Fixed grabbed objects teleporting

### DIFF
--- a/Assets/2. Assets/5. Particle Effects.meta
+++ b/Assets/2. Assets/5. Particle Effects.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 65226215dd3c46248a624638329d711a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/3. Scripts/CameraControl.cs
+++ b/Assets/3. Scripts/CameraControl.cs
@@ -171,8 +171,7 @@ public class CameraControl : MonoBehaviour
 	/// </summary>
 	public void GrabObject()
 	{
-		// TODO: Check for dynamic layer
-		if (Physics.Raycast(PlayerCamera.ViewportPointToRay(new Vector3(0.5f, 0.5f, 0.5f)), out RaycastHit RayOut, grabDistance))
+		if (Physics.Raycast(PlayerCamera.ViewportPointToRay(new Vector3(0.5f, 0.5f, 0.5f)), out RaycastHit RayOut, grabDistance, grabLayers))
 		{
 			if (RayOut.rigidbody != null)
 			{
@@ -195,7 +194,7 @@ public class CameraControl : MonoBehaviour
 				heldObject.drag = rigidBodyDrag;
 				heldObject.angularDrag = rigidBodyDragAngular;
 
-				heldObject.gameObject.transform.position = PlayerCamera.ViewportToWorldPoint(new Vector3(0.5f, 0.5f, holdDistance));
+				//heldObject.gameObject.transform.position = PlayerCamera.ViewportToWorldPoint(new Vector3(0.5f, 0.5f, holdDistance));
 			}
 		}
 	}


### PR DESCRIPTION
When you picked up an object it would jump to the position directly in
front of you, this has been removed.